### PR TITLE
Arange markers in an L-shape within the bounds

### DIFF
--- a/gdshelpers/geometry/ebl_frame_generators.py
+++ b/gdshelpers/geometry/ebl_frame_generators.py
@@ -3,10 +3,24 @@ from itertools import product
 from gdshelpers.parts.marker import SquareMarker
 
 
-def raith_marker_frame(bounds, padding=100, distance=200, size=20):
-    d1 = padding + distance / 2
-    d2 = distance / 2
+def raith_marker_frame(bounds, padding=100, pitch=200, size=20, n=5):
+    """
+    Generates a list of markers markers in each corner of the given bounding box.
+    In each corner the markers are aranged in an L shape. This allows to have more
+    markers (for exposure of many steps sometimes more than four markers are necessary)
+    with larger distance between the markers (minimize risk of wrong markers being
+    found by the EBL) without taking up too much space.
+    
+    :param bounds: The bounds within which the markers will be aranged (the marker centers will be inside these bounds)
+    :param padding: Spacing between the given bounds and the markers
+    :param pitch: Pitch between two adjacent markers
+    :param size: The marker size
+    :param n: This determines the number of markers: There will be (2*n)+1 markers in each corner.
+    """
+    marker_offsets = [(0,0)] + [(0, (i+1)*pitch) for i in range(n)] + [((i+1)*pitch, 0) for i in range(n)]
+    signs = product([-1,1], repeat=2)
+    x, y = 0.5 * (bounds[0] + bounds[2]), 0.5 * (bounds[1] + bounds[3])
+    half_width, half_height = 0.5*(bounds[2] - bounds[0]) - padding, 0.5*(bounds[3] - bounds[1]) - padding
 
-    return (SquareMarker((x + offset_x, y + offset_y), size)
-            for x, y, offset_x, offset_y in
-            product([bounds[0] - d1, bounds[2] + d1], [bounds[1] - d1, bounds[3] + d1], [-d2, d2], [-d2, d2]))
+    return [SquareMarker((x + (half_width - off[0])*sign[0], y + (half_height - off[1])*sign[1]), size)
+         for sign, off in product(signs, marker_offsets)]

--- a/gdshelpers/geometry/ebl_frame_generators.py
+++ b/gdshelpers/geometry/ebl_frame_generators.py
@@ -17,10 +17,10 @@ def raith_marker_frame(bounds, padding=100, pitch=200, size=20, n=5):
     :param size: The marker size
     :param n: This determines the number of markers: There will be (2*n)+1 markers in each corner.
     """
-    marker_offsets = [(0,0)] + [(0, (i+1)*pitch) for i in range(n)] + [((i+1)*pitch, 0) for i in range(n)]
-    signs = product([-1,1], repeat=2)
+    marker_offsets = [(0, 0)] + [(0, (i + 1) * pitch) for i in range(n)] + [((i + 1) * pitch, 0) for i in range(n)]
+    signs = product([-1, 1], repeat=2)
     x, y = 0.5 * (bounds[0] + bounds[2]), 0.5 * (bounds[1] + bounds[3])
-    half_width, half_height = 0.5*(bounds[2] - bounds[0]) + padding, 0.5*(bounds[3] - bounds[1]) + padding
-    
-    return [SquareMarker((x + (half_width - off[0])*sign[0], y + (half_height - off[1])*sign[1]), size)
+    half_width, half_height = 0.5 * (bounds[2] - bounds[0]) + padding, 0.5 * (bounds[3] - bounds[1]) + padding
+
+    return [SquareMarker((x + (half_width - off[0]) * sign[0], y + (half_height - off[1]) * sign[1]), size)
             for sign, off in product(signs, marker_offsets)]

--- a/gdshelpers/geometry/ebl_frame_generators.py
+++ b/gdshelpers/geometry/ebl_frame_generators.py
@@ -5,14 +5,14 @@ from gdshelpers.parts.marker import SquareMarker
 
 def raith_marker_frame(bounds, padding=100, pitch=200, size=20, n=5):
     """
-    Generates a list of markers markers in each corner of the given bounding box.
+    Generates a list of markers markers in each corner around the given bounding box.
     In each corner the markers are aranged in an L shape. This allows to have more
     markers (for exposure of many steps sometimes more than four markers are necessary)
     with larger distance between the markers (minimize risk of wrong markers being
     found by the EBL) without taking up too much space.
     
-    :param bounds: The bounds within which the markers will be aranged (the marker centers will be inside these bounds)
-    :param padding: Spacing between the given bounds and the markers
+    :param bounds: The bounds around which the markers will be aranged (the marker centers will be inside these bounds)
+    :param padding: Spacing between the given bounds and the markers. Can also be negative to place the markers inside the bounding box.
     :param pitch: Pitch between two adjacent markers
     :param size: The marker size
     :param n: This determines the number of markers: There will be (2*n)+1 markers in each corner.
@@ -20,7 +20,7 @@ def raith_marker_frame(bounds, padding=100, pitch=200, size=20, n=5):
     marker_offsets = [(0,0)] + [(0, (i+1)*pitch) for i in range(n)] + [((i+1)*pitch, 0) for i in range(n)]
     signs = product([-1,1], repeat=2)
     x, y = 0.5 * (bounds[0] + bounds[2]), 0.5 * (bounds[1] + bounds[3])
-    half_width, half_height = 0.5*(bounds[2] - bounds[0]) - padding, 0.5*(bounds[3] - bounds[1]) - padding
-
+    half_width, half_height = 0.5*(bounds[2] - bounds[0]) + padding, 0.5*(bounds[3] - bounds[1]) + padding
+    
     return [SquareMarker((x + (half_width - off[0])*sign[0], y + (half_height - off[1])*sign[1]), size)
-         for sign, off in product(signs, marker_offsets)]
+            for sign, off in product(signs, marker_offsets)]

--- a/gdshelpers/tests/test_ebl_frame_generators.py
+++ b/gdshelpers/tests/test_ebl_frame_generators.py
@@ -1,0 +1,25 @@
+import unittest
+from gdshelpers.geometry.ebl_frame_generators import raith_marker_frame
+import numpy as np
+
+
+class MarkerFrameTestCase(unittest.TestCase):
+    def test_raith_marker_frame(self):
+        bounds = (0, 0, 1000, 1000)
+        
+        markers = raith_marker_frame(bounds, padding=50, pitch=50, size=10, n=0)
+        self.assertEqual(len(markers), 4)
+        
+        markers = raith_marker_frame(bounds, padding=50, pitch=30, size=10, n=1)
+        self.assertEqual(len(markers), 12)
+        markerpositions = set([tuple(m.origin) for m in markers])
+        expected_markerpositions = set([(50, 50), (50, 80), (80, 50),
+                                        (950, 950), (950, 920), (920, 950),
+                                        (50, 950), (50, 920), (80, 950),
+                                        (950, 50), (950, 80), (920, 50)])
+        
+        self.assertEqual(markerpositions, expected_markerpositions)
+
+
+def test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(MarkerFrameTestCase)

--- a/gdshelpers/tests/test_ebl_frame_generators.py
+++ b/gdshelpers/tests/test_ebl_frame_generators.py
@@ -13,10 +13,10 @@ class MarkerFrameTestCase(unittest.TestCase):
         markers = raith_marker_frame(bounds, padding=50, pitch=30, size=10, n=1)
         self.assertEqual(len(markers), 12)
         markerpositions = set([tuple(m.origin) for m in markers])
-        expected_markerpositions = set([(50, 50), (50, 80), (80, 50),
-                                        (950, 950), (950, 920), (920, 950),
-                                        (50, 950), (50, 920), (80, 950),
-                                        (950, 50), (950, 80), (920, 50)])
+        expected_markerpositions = set([(-50, -50), (-50, -20), (-20, -50),
+                                        (1050, 1050), (1050, 1020), (1020, 1050),
+                                        (-50, 1050), (-50, 1020), (-20, 1050),
+                                        (1050, -50), (1050, -20), (1020, -50)])
         
         self.assertEqual(markerpositions, expected_markerpositions)
 


### PR DESCRIPTION
Arrange markers in an L shape in each corner. This allows to have more markers (for exposure of many steps sometimes more than four markers are necessary) with larger distance between the markers (minimize risk of wrong markers being found by the EBL) without taking up too much space.

![l_markers](https://user-images.githubusercontent.com/2996606/63692395-de3c3e00-c811-11e9-8040-0a22780936ef.png)
