### PR TITLE
Added multi width to single circle to port function

### DIFF
--- a/gdshelpers/parts/waveguide.py
+++ b/gdshelpers/parts/waveguide.py
@@ -411,17 +411,25 @@ class Waveguide(object):
         tmp_wg = Waveguide.make_at_port(self._current_port)
         tmp_wg.add_straight_segment(length=distance[0] - d)
         tmp_wg.add_bend(-diff_angle, radius)
+        if not on_line_only:
+            tmp_wg.add_straight_segment(distance[1] - d)
+        if final_width is not None:
+            tmp_segment_lengths = [segment[2] for segment in tmp_wg.get_segments()]
+            total_length = tmp_wg.length
+            tmp_segment_ratio = np.cumsum(tmp_segment_lengths / total_length)
+            segment_widths = [list((final_width - self.current_port.width) * ratio + self.current_port.width) for ratio
+                              in tmp_segment_ratio]
+            print(segment_widths[1])
+            tmp_wg = Waveguide.make_at_port(self._current_port)
+            tmp_wg.add_straight_segment(length=distance[0] - d, final_width=segment_widths[0])
+            tmp_wg.add_bend(-diff_angle, radius, final_width=segment_widths[1])
+            if not on_line_only:
+                tmp_wg.add_straight_segment(distance[1] - d, final_width=segment_widths[2])
 
         self._segments.append(
             (self._current_port.copy(), tmp_wg.get_shapely_object(), tmp_wg.get_shapely_outline(), tmp_wg.length,
              tmp_wg.center_coordinates))
         self._current_port = tmp_wg.current_port
-
-        if not on_line_only:
-            if final_width is not None:
-                self.add_straight_segment(length=distance[1] - d, final_width=final_width)
-            else:
-                self.add_straight_segment(distance[1] - d)
 
         return self
 

--- a/gdshelpers/parts/waveguide.py
+++ b/gdshelpers/parts/waveguide.py
@@ -357,7 +357,7 @@ class Waveguide(object):
         self.add_bezier_to(port.origin, port.inverted_direction.angle, bend_strength, width, **kwargs)
         return self
 
-    def add_route_single_circle_to(self, final_coordinates, final_angle, max_bend_strength=None,
+    def add_route_single_circle_to(self, final_coordinates, final_angle, final_width=None, max_bend_strength=None,
                                    on_line_only=False):
 
         """
@@ -409,7 +409,7 @@ class Waveguide(object):
         d = abs(radius * np.tan(diff_angle / 2))
 
         tmp_wg = Waveguide.make_at_port(self._current_port)
-        tmp_wg.add_straight_segment(distance[0] - d)
+        tmp_wg.add_straight_segment(length=distance[0] - d)
         tmp_wg.add_bend(-diff_angle, radius)
 
         self._segments.append(
@@ -418,7 +418,10 @@ class Waveguide(object):
         self._current_port = tmp_wg.current_port
 
         if not on_line_only:
-            self.add_straight_segment(distance[1] - d)
+            if final_width is not None:
+                self.add_straight_segment(length=distance[1] - d, final_width=final_width)
+            else:
+                self.add_straight_segment(distance[1] - d)
 
         return self
 
@@ -431,7 +434,8 @@ class Waveguide(object):
         :param max_bend_strength: The maximum allowed bending radius.
         :param on_line_only: Omit the last straight line and only route to line described by port.
         """
-        self.add_route_single_circle_to(port.origin, port.inverted_direction.angle, max_bend_strength, on_line_only)
+        self.add_route_single_circle_to(port.origin, port.inverted_direction.angle, port.width, max_bend_strength,
+                                        on_line_only)
         return self
 
     def add_straight_segment_to_intersection(self, line_origin, line_angle, **line_kw):

--- a/gdshelpers/parts/waveguide.py
+++ b/gdshelpers/parts/waveguide.py
@@ -382,7 +382,7 @@ class Waveguide(object):
         """
         # We are given an out angle, but the internal math is for inward pointing lines
         final_angle = normalize_phase(final_angle) + np.pi
-
+        final_width = final_width if final_width is not None else self.width
         # We need to to some linear algebra. We first find the intersection of the two waveguides
         r1 = self._current_port.origin
         r2 = np.array(final_coordinates)


### PR DESCRIPTION
I want to add a tapering option for the single circe function of the waveguide class. 
![image](https://user-images.githubusercontent.com/53610169/70541798-fdb06a00-1b67-11ea-9a5f-be5ed2f0eb0b.png)
![image](https://user-images.githubusercontent.com/53610169/70546493-b0d09180-1b6f-11ea-8bc3-ccbd237cf7ac.png)

To do:

- [x] Apply tapering to the whole structure.