### PR TITLE
Fixed usage of linspace in waveguide.py due to changes in numpy.

### DIFF
--- a/gdshelpers/parts/waveguide.py
+++ b/gdshelpers/parts/waveguide.py
@@ -180,7 +180,7 @@ class Waveguide:
         """
 
         if callable(path):
-            presample_t = np.linspace(0, 1, int(sample_points))
+            presample_t = np.linspace(0, 1, sample_points)
 
             if path_function_supports_numpy:
                 presample_coordinates = np.array(path(presample_t)).T
@@ -223,7 +223,7 @@ class Waveguide:
         else:
             # If we do not have a sample function, we need to "invent a sampling parameter"
             sample_coordinates = np.array(path)
-            sample_t = np.linspace(0, 1, int(sample_coordinates.shape[0]))
+            sample_t = np.linspace(0, 1, sample_coordinates.shape[0])
 
         rotation_matrix = np.array(((np.cos(self._current_port.angle), -np.sin(self._current_port.angle)),
                                     (np.sin(self._current_port.angle), np.cos(self._current_port.angle))))

--- a/gdshelpers/parts/waveguide.py
+++ b/gdshelpers/parts/waveguide.py
@@ -180,7 +180,7 @@ class Waveguide:
         """
 
         if callable(path):
-            presample_t = np.linspace(0, 1, sample_points)
+            presample_t = np.linspace(0, 1, int(sample_points))
 
             if path_function_supports_numpy:
                 presample_coordinates = np.array(path(presample_t)).T
@@ -200,7 +200,7 @@ class Waveguide:
 
                 lengths = np.linspace(presample_coordinates_d1__cum_norm[0],
                                       presample_coordinates_d1__cum_norm[-1],
-                                      presample_coordinates_d1__cum_norm[-1] // sample_distance)
+                                      int(presample_coordinates_d1__cum_norm[-1] / sample_distance))
 
                 # First get the spline representation. This is needed since we manipulate these directly for roots
                 # finding.
@@ -223,7 +223,7 @@ class Waveguide:
         else:
             # If we do not have a sample function, we need to "invent a sampling parameter"
             sample_coordinates = np.array(path)
-            sample_t = np.linspace(0, 1, sample_coordinates.shape[0])
+            sample_t = np.linspace(0, 1, int(sample_coordinates.shape[0]))
 
         rotation_matrix = np.array(((np.cos(self._current_port.angle), -np.sin(self._current_port.angle)),
                                     (np.sin(self._current_port.angle), np.cos(self._current_port.angle))))


### PR DESCRIPTION
An update in numpy requires num from numpy.linspace(start,stop,num) to be an integer (see https://numpy.org/devdocs/release/1.18.0-notes.html#expired-deprecations). 