### PR TITLE
GratingCoupler: allow for apodized grating period in make_traditional_coupler

### DIFF
--- a/gdshelpers/parts/coupler.py
+++ b/gdshelpers/parts/coupler.py
@@ -70,7 +70,7 @@ class GratingCoupler:
     @classmethod
     def make_traditional_coupler(cls, origin, width, full_opening_angle, grating_period, grating_ff, n_gratings,
                                  ap_max_ff=1.0, n_ap_gratings=0, taper_length=None, extra_triangle_layer=False,
-                                 angle=-np.pi / 2, n_points=394, implement_cadence_ff_bug=True):
+                                 angle=-np.pi / 2, n_points=394, implement_cadence_ff_bug=True, ap_start_period=None):
         """
         Generate a traditional coupler as the ``lib/coupler/`` functions did. But this version is versatile enough
         to generate all kinds of couplers, including:
@@ -106,6 +106,9 @@ class GratingCoupler:
                       upwards.
         :parameter implement_cadence_ff_bug:
         :type implement_cadence_ff_bug: bool
+        :param ap_start_period: The starting period in the apodized region. If a value is passed, the period will
+                                be swept from `ap_start_period` to `grating_period` over the apodized gratings.
+                                If None, the period will be constant.
 
         :return: The constructed traditional grating coupler.
         :rtype: GratingCoupler
@@ -127,9 +130,13 @@ class GratingCoupler:
                 DeprecationWarning)
             apodized_ffs = np.linspace(ap_max_ff, grating_ff, n_ap_gratings + 1)[1:]
 
-        for ap_ff in apodized_ffs:
-            radii.append(grating_period * (1 - ap_ff))
-            radii.append(grating_period * ap_ff)
+        # Period in the apodized region
+        ap_periods = np.linspace(
+            ap_start_period if ap_start_period is not None else grating_period, grating_period, n_ap_gratings)
+
+        for ap_period, ap_ff in zip(ap_periods, apodized_ffs):
+            radii.append(ap_period * (1 - ap_ff))
+            radii.append(ap_period * ap_ff)
 
         # Add simple gratings with constant ff
         radii.extend([grating_period * (1 - grating_ff), grating_period * grating_ff] * n_gratings)
@@ -148,7 +155,8 @@ class GratingCoupler:
             'n_ap_gratings': n_ap_gratings,
             'taper_length': taper_length,
             'implement_cadence_ff_bug': implement_cadence_ff_bug,
-            'full_opening_angle': full_opening_angle
+            'full_opening_angle': full_opening_angle,
+            'ap_start_period': ap_start_period
         }
 
         return obj

--- a/gdshelpers/parts/coupler.py
+++ b/gdshelpers/parts/coupler.py
@@ -76,8 +76,8 @@ class GratingCoupler:
         to generate all kinds of couplers, including:
 
             - constant fill factor couplers
-            - apodized couplers (where the fill factor is varied from ap_max_ff to grating_ff over
-                                 n_ap_gratings gratings.)
+            - apodized couplers (where the fill factor is varied from ap_max_ff to grating_ff and the grating period
+                                 is varied from ap_start_period to grating_period over n_ap_gratings gratings.)
 
         All couplers can have the taper triangle separated onto its own layer for better e-beam dose.
 

--- a/gdshelpers/tests/test_coupler.py
+++ b/gdshelpers/tests/test_coupler.py
@@ -1,0 +1,61 @@
+import unittest
+
+from gdshelpers.parts.coupler import GratingCoupler
+from gdshelpers.geometry.chip import Cell
+import numpy as np
+
+
+class GratingCouplerTestCase(unittest.TestCase):
+    def test_coupler_apodized_period(self):
+        coupler1 = GratingCoupler.make_traditional_coupler(
+            origin=[0, 0],
+            width=1,
+            full_opening_angle=np.deg2rad(40),
+            grating_period=3,
+            grating_ff=0.5,
+            n_gratings=22,
+            ap_max_ff=0.25,
+            n_ap_gratings=10,
+            taper_length=22,
+            angle=-0.5 * np.pi,
+            ap_start_period=1.,
+        )
+
+        coupler2 = GratingCoupler.make_traditional_coupler(
+            origin=[100, 0],
+            width=1,
+            full_opening_angle=np.deg2rad(40),
+            grating_period=3,
+            grating_ff=0.5,
+            n_gratings=22,
+            ap_max_ff=0.25,
+            n_ap_gratings=10,
+            taper_length=22,
+            angle=-0.5 * np.pi,
+            ap_start_period=3.,
+        )
+
+        coupler3 = GratingCoupler.make_traditional_coupler(
+            origin=[200, 0],
+            width=1,
+            full_opening_angle=np.deg2rad(40),
+            grating_period=3,
+            grating_ff=0.5,
+            n_gratings=22,
+            ap_max_ff=0.25,
+            n_ap_gratings=10,
+            taper_length=22,
+            angle=-0.5 * np.pi,
+            ap_start_period=None,
+        )
+
+        self.assertAlmostEqual(coupler2.maximal_radius, coupler3.maximal_radius)
+
+        layout = Cell('LIBRARY')
+        cell = Cell('TOP')
+        cell.add_to_layer(1, coupler1)
+        cell.add_to_layer(1, coupler2)
+        cell.add_to_layer(1, coupler3)
+        layout.add_cell(cell)
+
+        # cell.save('test_coupler')


### PR DESCRIPTION
In GratingCoupler.make_traditional_coupler, add the parameter `ap_start_period` to allow for changing the grating period in the apodized region