### PR TITLE
Add Waveguide.add_route_straight_to_port

### DIFF
--- a/gdshelpers/parts/waveguide.py
+++ b/gdshelpers/parts/waveguide.py
@@ -470,9 +470,9 @@ class Waveguide:
         end_deriv = np.array([np.cos(angle_diff), np.sin(angle_diff)])
 
         self.add_parameterized_path(path=lambda t: np.array([0, 0]) * (1 - t) + end_point * t,
-                                        width=lambda t: start_width * (1 - t) + final_width * t,
-                                        path_derivative=lambda t: start_deriv * (1 - t) + end_deriv * t,
-                                        sample_points=2, sample_distance=0)
+                                    width=lambda t: start_width * (1 - t) + final_width * t,
+                                    path_derivative=lambda t: start_deriv * (1 - t) + end_deriv * t,
+                                    sample_points=2, sample_distance=0)
 
         return self
 

--- a/gdshelpers/tests/test_waveguide.py
+++ b/gdshelpers/tests/test_waveguide.py
@@ -2,6 +2,7 @@ import unittest
 import math
 
 from gdshelpers.parts.waveguide import Waveguide
+from gdshelpers.parts.port import Port
 
 
 class WaveguideTestCase(unittest.TestCase):
@@ -39,3 +40,36 @@ class WaveguideTestCase(unittest.TestCase):
         wg.add_straight_segment(100)
         wg.add_parameterized_path(some_path)
         wg.get_shapely_object()
+
+    def test_waveguide_add_route_straight_to_port(self):
+        import numpy as np
+        start_port = Port([0, 0], 0.5*np.pi, 1)
+        end_port = Port([10, 10], 0.5*np.pi, 3)
+
+        wg = Waveguide.make_at_port(start_port)
+        wg.add_straight_segment(2)
+        wg.add_route_straight_to_port(end_port)
+        wg.add_straight_segment(2)
+
+        self.assertAlmostEqual(wg.current_port.angle, 0.5*np.pi)
+        self.assertAlmostEqual(wg.current_port.width, 3)
+        self.assertAlmostEqual(wg.current_port.origin[0], 10)
+        self.assertAlmostEqual(wg.current_port.origin[1], 12)
+
+        end_port2 = Port([10, 10], 0, 3)
+        wg2 = Waveguide.make_at_port(start_port)
+        wg2.add_straight_segment(2)
+        wg2.add_route_straight_to_port(end_port2)
+        wg2.add_straight_segment(2)
+
+        self.assertAlmostEqual((wg2.current_port.angle + 0.5) % (2*np.pi), 0.5)
+        self.assertAlmostEqual(wg2.current_port.width, 3)
+        self.assertAlmostEqual(wg2.current_port.origin[0], 12)
+        self.assertAlmostEqual(wg2.current_port.origin[1], 10)
+
+        """ # Enable to generate output
+        from gdshelpers.geometry.chip import Cell
+        cell = Cell("test")
+        cell.add_to_layer(11, wg)
+        cell.add_to_layer(12, wg2)
+        cell.save("wgtest.gds")"""


### PR DESCRIPTION
Add method `add_route_straight_to_port` to Waveguide. Allows routing a straight segment to a target port and tapers the width linearly on the way.

This can be used for electrode contact pads etc.

![route_port](https://user-images.githubusercontent.com/2996606/97446136-57f81c00-192e-11eb-9f71-8e7825b38878.png)
