### PR TITLE
Fix waveguide route straight

### DIFF
--- a/gdshelpers/parts/waveguide.py
+++ b/gdshelpers/parts/waveguide.py
@@ -467,7 +467,7 @@ class Waveguide:
         R = np.array([[c, -s], [s, c]])
         end_point = R @ (np.array(port.origin) - np.array(self.current_port.origin))
 
-        angle_diff = port.angle - self.current_port.angle
+        angle_diff = port.inverted_direction.angle - self.current_port.angle
         start_deriv = np.array([1, 0])
         end_deriv = np.array([np.cos(angle_diff), np.sin(angle_diff)])
 

--- a/gdshelpers/tests/test_waveguide.py
+++ b/gdshelpers/tests/test_waveguide.py
@@ -84,3 +84,33 @@ class WaveguideTestCase(unittest.TestCase):
         for i, wg in enumerate(waveguides):
             cell.add_to_layer(1+i, wg)
         cell.save("wgtest.gds")"""
+
+    def test_route_to_port_functions(self):
+        """
+        Test consistency of route functions of the Waveguide class.
+        Verify that the port to be routed to points in the direction
+        of the waveguide to route from.
+        """
+        import numpy as np
+
+        xmax = 200
+
+        start_port = Port([0, 0], 0.5*np.pi, 1)
+        target_port = Port([xmax, 200], 0, 1)
+
+        wg1 = Waveguide.make_at_port(start_port)
+        wg1.add_route_single_circle_to_port(target_port.inverted_direction)
+
+        wg2 = Waveguide.make_at_port(start_port)
+        wg2.add_bezier_to_port(target_port.inverted_direction, bend_strength=50)
+
+        wg3 = Waveguide.make_at_port(start_port)
+        wg3.add_route_straight_to_port(target_port.inverted_direction)
+
+        # Check that they are all within the bounding box (to prevent routing from the wrong side)
+        # (This would fail, for example, for add_bezier_to_port if routed to target_port instead of
+        # target_port.inverted_direction, which both works)
+        for wg in [wg1, wg2, wg3]:
+            bounds = wg.get_shapely_object().bounds
+            print(bounds)
+            self.assertLessEqual(bounds[2], xmax)

--- a/gdshelpers/tests/test_waveguide.py
+++ b/gdshelpers/tests/test_waveguide.py
@@ -68,7 +68,7 @@ class WaveguideTestCase(unittest.TestCase):
         for end_port, target_pos in test_data:
             wg = Waveguide.make_at_port(start_port)
             wg.add_straight_segment(2)
-            wg.add_route_straight_to_port(end_port)
+            wg.add_route_straight_to_port(end_port.inverted_direction)
             wg.add_straight_segment(2)
 
             waveguides.append(wg)


### PR DESCRIPTION
All route to port functions expect the target port to be pointing towards the current_port of the waveguide to be routed.
This fixes add_route_straight_to_port to be consistent and adds a testcase.