### PR TITLE
Add parse_alphanumeric as inverse of id_to_alphanumeric

### DIFF
--- a/gdshelpers/helpers/small.py
+++ b/gdshelpers/helpers/small.py
@@ -1,6 +1,7 @@
 import string
 import numpy as np
 import numpy.linalg as linalg
+import re
 
 
 def raith_eline_dosefactor_to_datatype(dose_factor):
@@ -45,6 +46,20 @@ def id_to_alphanumeric(column, row):
     :rtype: str
     """
     return int_to_alphabet(row) + str(int(column))
+
+
+def parse_alphanumeric(text):
+    """
+    Do the reverse of `id_to_alphanumeric`.
+    Returns the (column, row) tuple.
+    """
+    regex = "([A-Z]*)[^0-9]*([0-9]*)"
+    m = re.match(regex, text.strip(), re.I)
+    letters, number = m.group(1), int(m.group(2))
+    letter_num = 0
+    for i in range(len(letters)):
+        letter_num += (ord(letters[i]) - 64) * (26 ** (len(letters) - i - 1))
+    return number, letter_num - 1
 
 
 def normalize_phase(phase, zero_to_two_pi=False):

--- a/gdshelpers/helpers/small.py
+++ b/gdshelpers/helpers/small.py
@@ -48,17 +48,15 @@ def id_to_alphanumeric(column, row):
     return int_to_alphabet(row) + str(int(column))
 
 
-def parse_alphanumeric(text):
+def alphanumeric_to_id(text):
     """
     Do the reverse of `id_to_alphanumeric`.
-    Returns the (column, row) tuple.
+    :return: (column, row) tuple.
     """
-    regex = "([A-Z]*)[^0-9]*([0-9]*)"
-    m = re.match(regex, text.strip(), re.I)
+    regex = "([A-Z]*)([0-9]*)"
+    m = re.match(regex, text, re.I)
     letters, number = m.group(1), int(m.group(2))
-    letter_num = 0
-    for i in range(len(letters)):
-        letter_num += (ord(letters[i]) - 64) * (26 ** (len(letters) - i - 1))
+    letter_num = sum((ord(letter) - ord('A') + 1) * 26 ** i for i, letter in enumerate(letters[::-1]))
     return number, letter_num - 1
 
 

--- a/gdshelpers/tests/test_helpers.py
+++ b/gdshelpers/tests/test_helpers.py
@@ -3,7 +3,7 @@ import numpy as np
 import numpy.testing as npt
 
 from gdshelpers.helpers import int_to_alphabet, id_to_alphanumeric, find_line_intersection
-from gdshelpers.helpers.small import parse_alphanumeric
+from gdshelpers.helpers.small import alphanumeric_to_id
 
 
 class HelpersTestCase(unittest.TestCase):
@@ -17,11 +17,10 @@ class HelpersTestCase(unittest.TestCase):
         self.assertEqual(id_to_alphanumeric(4, 26 + 25), 'AZ4')
 
     def test_parse_alphanumeric(self):
-        self.assertEqual((4, 26 + 25), parse_alphanumeric('AZ4'))
-        self.assertEqual((4, 26 + 25), parse_alphanumeric(' AZ4 '))
+        self.assertEqual((4, 26 + 25), alphanumeric_to_id('AZ4'))
 
         for pair in [(0, 0), (0, 10), (0, 100), (100, 0), (100, 100)]:
-            self.assertEqual(pair, parse_alphanumeric(id_to_alphanumeric(*pair)))
+            self.assertEqual(pair, alphanumeric_to_id(id_to_alphanumeric(*pair)))
 
     def test_find_line_intersection(self):
         test_intersection = find_line_intersection(np.array((2, 0)), np.pi / 2, np.array((0, 1)), 0)

--- a/gdshelpers/tests/test_helpers.py
+++ b/gdshelpers/tests/test_helpers.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.testing as npt
 
 from gdshelpers.helpers import int_to_alphabet, id_to_alphanumeric, find_line_intersection
+from gdshelpers.helpers.small import parse_alphanumeric
 
 
 class HelpersTestCase(unittest.TestCase):
@@ -14,6 +15,13 @@ class HelpersTestCase(unittest.TestCase):
 
     def test_id_to_alphanumeric(self):
         self.assertEqual(id_to_alphanumeric(4, 26 + 25), 'AZ4')
+
+    def test_parse_alphanumeric(self):
+        self.assertEqual((4, 26 + 25), parse_alphanumeric('AZ4'))
+        self.assertEqual((4, 26 + 25), parse_alphanumeric(' AZ4 '))
+
+        for pair in [(0, 0), (0, 10), (0, 100), (100, 0), (100, 100)]:
+            self.assertEqual(pair, parse_alphanumeric(id_to_alphanumeric(*pair)))
 
     def test_find_line_intersection(self):
         test_intersection = find_line_intersection(np.array((2, 0)), np.pi / 2, np.array((0, 1)), 0)

--- a/gdshelpers/tests/test_helpers.py
+++ b/gdshelpers/tests/test_helpers.py
@@ -16,7 +16,7 @@ class HelpersTestCase(unittest.TestCase):
     def test_id_to_alphanumeric(self):
         self.assertEqual(id_to_alphanumeric(4, 26 + 25), 'AZ4')
 
-    def test_parse_alphanumeric(self):
+    def test_alphanumeric_to_id(self):
         self.assertEqual((4, 26 + 25), alphanumeric_to_id('AZ4'))
 
         for pair in [(0, 0), (0, 10), (0, 100), (100, 0), (100, 100)]:


### PR DESCRIPTION
Small helper utility for parsing device codes in a matrix such as 'A3', 'A4', etc.