### PR TITLE
Desc format

### DIFF
--- a/gdshelpers/geometry/chip.py
+++ b/gdshelpers/geometry/chip.py
@@ -220,11 +220,13 @@ class Cell:
         """
         def walk_cells(cell, out_dict):
             if cell.name not in out_dict:
-                out_dict[cell.name] = {
-                    'cells': {child['cell'].name: dict(offset=tuple(child['origin']),
-                                                       angle=child['angle'] or 0) for child in cell.cells},
-                    **cell.desc
-                }
+                cellrefs = []
+                for child in cell.cells:
+                    child_dict = child.copy()
+                    child_dict['cell'] = child_dict['cell'].name
+                    cellrefs.append(child_dict)
+
+                out_dict[cell.name] = {'cells': cellrefs, **cell.desc}
 
                 for child in cell.cells:
                     walk_cells(child['cell'], out_dict)

--- a/gdshelpers/geometry/chip.py
+++ b/gdshelpers/geometry/chip.py
@@ -208,9 +208,29 @@ class Cell:
         return dlw_data
 
     def get_desc(self):
-        desc = self.desc.copy()
-        desc['cells'] = {cell['cell'].name: dict(offset=tuple(cell['origin']), angle=cell['angle'] or 0,
-                                                 **cell['cell'].get_desc()) for cell in self.cells}
+        """
+        Creates and returns a dictionary containing all the 'desc' data of this cell and all children.
+        The returned dictionary contains two keys:
+
+        * `root`: The name of the root cell (the cell from which `get_desc` was called)
+        * `cells`: Dictionary mapping cell names to the desc data of each cell as well as cell references to other cells
+                   (with origin and angle).
+
+        :return: Dictionary containing the `desc` data for this cell and all cells referenced by this cell
+        """
+        def walk_cells(cell, out_dict):
+            if cell.name not in out_dict:
+                out_dict[cell.name] = {
+                    'cells': {child['cell'].name: dict(offset=tuple(child['origin']),
+                                                       angle=child['angle'] or 0) for child in cell.cells},
+                    **cell.desc
+                }
+
+                for child in cell.cells:
+                    walk_cells(child['cell'], out_dict)
+
+        desc = dict(root=self.name, cells=dict())
+        walk_cells(self, desc['cells'])
         return desc
 
     def get_fractured_layer_dict(self, max_points=4000, max_line_points=4000):

--- a/gdshelpers/tests/test_chip.py
+++ b/gdshelpers/tests/test_chip.py
@@ -180,3 +180,16 @@ class DeviceTestCase(unittest.TestCase):
         top.add_cell(child2, [0, 0])
         with self.assertRaises(ValueError):
             top.add_cell(child2, [100, 0])
+
+    def test_desc(self):
+        cell = Cell("desctest")
+        c1 = Cell("child1")
+        c1.add_to_desc("foo", 123)
+        cell.add_cell(c1, origin=(0, 0))
+        cell.add_cell(c1, origin=(100, 0), angle=2)
+
+        d = cell.get_desc()
+        self.assertTrue("child1" in d["cells"])
+        self.assertTrue("desctest" in d["cells"])
+        self.assertEqual("desctest", d["root"])
+        self.assertEqual(2, len(d["cells"]["desctest"]["cells"]))

--- a/gdshelpers/tests/test_chip.py
+++ b/gdshelpers/tests/test_chip.py
@@ -193,3 +193,4 @@ class DeviceTestCase(unittest.TestCase):
         self.assertTrue("desctest" in d["cells"])
         self.assertEqual("desctest", d["root"])
         self.assertEqual(2, len(d["cells"]["desctest"]["cells"]))
+        self.assertEqual("child1", d["cells"]["desctest"]["cells"][0]["cell"])


### PR DESCRIPTION
Suggestion for a new format for the `desc` output dictionary.
This follows more closely the idea of GDSII that each cell is identified by a unique name and can be referenced mulitple times.

With this new format, the resulting dict will only contain the desc data for each cell once and just store (name) references to the other cells. 

Basically, the resulting dict will look somewhat like this:
```
{
    "root": "name_of_root_cell",
    "cells": {
        "name_of_root_cell": {
            "desc": {...},
            "cells": [ <list of all cells referenced by this cell (with origin, angle etc.)>  ]
        },
        "other_cell": {
            "desc": {...},
            "cells": [ <list of all cells referenced by this cell (with origin, angle etc.)>  ]
        },
    }
}
```