### PR TITLE
Allow cell reuse when creating cells in parallel

### DIFF
--- a/gdshelpers/geometry/chip.py
+++ b/gdshelpers/geometry/chip.py
@@ -10,6 +10,7 @@ from gdshelpers.export.gdsii_export import write_cell_to_gdsii_file
 from gdshelpers.geometry import geometric_union
 from gdshelpers.parts.port import Port
 import gdshelpers.helpers.layers as std_layers
+import uuid
 
 
 class Cell:
@@ -31,6 +32,10 @@ class Cell:
         # Children cells have to be queried each time, since there is no way of knowing when they got changed.
         # self._bounds is None if the bounds need to be recalculated or if the cell is empty (in which case
         # recalculating them is cheap and we don't need to cache them)
+
+        self._uuid = uuid.uuid4()
+        # assign a unique UUID for this cell such that we can identify cells which have been pickled or
+        # serialized.
 
     @property
     def bounds(self):

--- a/gdshelpers/tests/test_gdsii_export_import.py
+++ b/gdshelpers/tests/test_gdsii_export_import.py
@@ -5,7 +5,19 @@ from shapely.affinity import translate, rotate
 
 from gdshelpers.parts.waveguide import Waveguide
 from gdshelpers.geometry.chip import Cell
+from gdshelpers.parts.coupler import GratingCoupler
+from gdshelpers.parts.port import Port
 from gdshelpers.parts.pattern_import import GDSIIImport
+
+
+def make_test_cell(args):
+    # Helper function for the test case 'test_parallel'.
+    # Needs to be global so that it can be pickled for parallel execution
+    i, gc_cell, port = args
+    cell = Cell('complex_cell_{}'.format(i))
+    cell.add_to_layer(1, Waveguide.make_at_port(port).add_straight_segment(10))
+    cell.add_cell(gc_cell, [0, 0])
+    return i, cell
 
 
 class GdsTestCase(unittest.TestCase):
@@ -60,3 +72,36 @@ class GdsTestCase(unittest.TestCase):
         cells[0].save('parallel.gds', parallel=True)
 
         self.assertTrue(filecmp.cmp('serial.gds', 'parallel.gds'))
+
+    def test_parallel_cell_reuse(self):
+        """
+        This test case tests if it is possible to generate Cells in parallel when they
+        reuse a common sub cell.
+        This can be useful when creating a cell is an expensive operation and should
+        be parallelized, but some components (such as grating couplers) can be reused.
+        """
+        from concurrent.futures import ProcessPoolExecutor
+        port = Port([0, 0], 0, 1.)
+
+        # Create a common cell for grating couplers, which is reused
+        gc_cell = Cell("gc")
+        gc = GratingCoupler.make_traditional_coupler_at_port(port.inverted_direction,
+                                                             full_opening_angle=np.deg2rad(40),
+                                                             grating_period=1.13,
+                                                             grating_ff=0.85,
+                                                             n_gratings=20)
+        gc_cell.add_to_layer(1, gc)
+
+        top_cell = Cell("top")
+        with ProcessPoolExecutor(max_workers=4) as executor:
+            for i, cell in executor.map(make_test_cell, [(i, gc_cell, port) for i in range(8)]):
+                top_cell.add_cell(cell, origin=[i*100, 0])
+
+        top_cell.save("test_parallel.gds")
+
+        # However, adding two different cells with the same name should still be prohibited
+        top_cell.add_cell(Cell("foo"))
+        top_cell.add_cell(Cell("foo"))
+
+        with self.assertRaises(AssertionError):
+            top_cell.save("test_parallel.gds")


### PR DESCRIPTION
Sometime, the cell creation is expensive and benefits from parallelization. At the same time, some sub-cells can be reused between  cells.

Currently, this fails because when ProcessPoolExecutor (or similar parallelization structures) are used, sub-cells are pickled and deserialized again. When merging the parallel cells together in the end, comparison for those sub-cells fails because they have no common identity anymore.

This adds a UUID when a cell is created, such that cells can be identified by their UUID.

Possible downside is that if a user modifies a sub-cell after it has been pickled, the changes might get lost, but this can easily be avoided by finishing the sub-cell before using it.