### PR TITLE
Fix bounding box calculation for rotated cells

### DIFF
--- a/gdshelpers/geometry/shapely_adapter.py
+++ b/gdshelpers/geometry/shapely_adapter.py
@@ -403,14 +403,14 @@ def transform_bounds(bounds, origin, rotation=0, scale=1.):
     """
     Transform a bounds tuple (xmin, ymin, xmax, ymax) by the given offset, rotation and scale.
     """
-    bounds = scale * np.array(bounds).reshape(2, 2) + origin
     if rotation != 0:
-        center = 0.5 * (bounds[0, :] + bounds[1, :])
-        size = np.abs(bounds[1, :] - bounds[0, :])
+        (xmin, ymin, xmax, ymax) = bounds
         c, s = np.cos(rotation), np.sin(rotation)
-        rot_matrix = np.array([[c, -s], [s, c]])  # rotation matrix
-        new_half_size = 0.5 * np.abs(rot_matrix).dot(size)
-        new_center = rot_matrix.dot(center)
-        bounds = np.array([new_center - new_half_size, new_center + new_half_size])
+        rot_matrix = scale * np.array([[c, -s], [s, c]])  # rotation matrix
+        corners = [(xmin, ymin), (xmin, ymax), (xmax, ymin), (xmax, ymax)]
+        corners = np.array([rot_matrix.dot(c) for c in corners]) + origin
 
-    return bounds.flatten()
+        bounds = np.min(corners[:, 0]), np.min(corners[:, 1]), np.max(corners[:, 0]), np.max(corners[:, 1])
+        return bounds
+    else:
+        return (scale * np.array(bounds).reshape(2, 2) + origin).flatten()

--- a/gdshelpers/tests/test_chip.py
+++ b/gdshelpers/tests/test_chip.py
@@ -54,6 +54,20 @@ class DeviceTestCase(unittest.TestCase):
 
         # cell.save('test_cell_bounds')
 
+    def test_bounds_subcell(self):
+        cell = Cell('test_cell')
+
+        subcell = Cell('subcell')
+        subcell.add_to_layer(3, box(0, 0, 100, 100))
+        cell.add_cell(subcell, origin=(100, 100))
+        self.assertEqual(cell.bounds, (100, 100, 200, 200))
+
+        cell.add_cell(subcell, origin=(500, 100), angle=np.pi)
+
+        # cell.save('test_bounds_subcell')
+
+        self.assertEqual(cell.bounds, (100, 0, 500, 200))
+
     def test_empty_cell(self):
         # An empty cell should have 'None' as bounding box
         cell = Cell('test_cell')


### PR DESCRIPTION
The calculation of bounding box was previously wrong, as the test case shows.